### PR TITLE
Handle different content types for validator registrations.

### DIFF
--- a/services/validatorregistrar/mock/handler.go
+++ b/services/validatorregistrar/mock/handler.go
@@ -1,0 +1,38 @@
+// Copyright © 2022, 2023 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mock
+
+import (
+	"context"
+
+	"github.com/attestantio/go-block-relay/types"
+)
+
+// HandlerService is a mock validator registrar.
+type HandlerService struct{}
+
+// NewHandler creates a new mock validator registrar that handles registrations.
+func NewHandler() *HandlerService {
+	return &HandlerService{}
+}
+
+// ValidatorRegistrations handles validator registrations.
+func (s *HandlerService) ValidatorRegistrations(_ context.Context,
+	_ []*types.SignedValidatorRegistration,
+) (
+	[]string,
+	error,
+) {
+	return nil, nil
+}

--- a/services/validatorregistrar/mock/passthrough.go
+++ b/services/validatorregistrar/mock/passthrough.go
@@ -1,0 +1,37 @@
+// Copyright © 2022, 2023 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mock
+
+import (
+	"context"
+	"io"
+)
+
+// PassthroughService is a mock validator registrar.
+type PassthroughService struct{}
+
+// NewPassthrough creates a new mock validator registrar with a passthrough.
+func NewPassthrough() *PassthroughService {
+	return &PassthroughService{}
+}
+
+// ValidatorRegistrationsPassthrough handles validator registrations directly.
+func (s *PassthroughService) ValidatorRegistrationsPassthrough(_ context.Context,
+	_ io.ReadCloser,
+) (
+	[]string,
+	error,
+) {
+	return nil, nil
+}


### PR DESCRIPTION
Check the `Content-Type` header for validator registrations, and reject if not supported.

Fixes https://github.com/attestantio/vouch/issues/296